### PR TITLE
Remove unused special symbol logic for Labyrinth of the Titans

### DIFF
--- a/games/kyv_lab_titans/game_override.py
+++ b/games/kyv_lab_titans/game_override.py
@@ -1,5 +1,4 @@
 from game_executables import GameExecutables
-from src.calculations.statistics import get_random_outcome
 
 
 class GameStateOverride(GameExecutables):
@@ -12,20 +11,6 @@ class GameStateOverride(GameExecutables):
         """Reset game specific properties"""
         super().reset_book()
 
-    def assign_special_sym_function(self):
-        self.special_symbol_functions = {
-            "M": [self.assign_mult_property],
-            "W": [self.assign_mult_property],
-        }
-
-    def assign_mult_property(self, symbol):
-        multiplier_value = get_random_outcome(
-            self.get_current_distribution_conditions()["mult_values"][self.gametype]
-        )
-        symbol.multiplier = multiplier_value
-
     def check_game_repeat(self):
-        if self.repeat == False:
-            win_criteria = self.get_current_betmode_distributions().get_win_criteria()
-            if win_criteria is not None and self.final_win != win_criteria:
-                self.repeat = True
+        """Verify final win meets required betmode conditions."""
+        super().check_repeat()


### PR DESCRIPTION
## Summary
- drop unused special symbol functions and multiplier logic from Labyrinth of the Titans override
- streamline `reset_book` and `check_game_repeat` to only relevant behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a6bb21064832098fdf69505487257