### PR TITLE
Implement key and multiplier mechanics for Labyrinth of the Titans

### DIFF
--- a/games/kyv_lab_titans/game_calculations.py
+++ b/games/kyv_lab_titans/game_calculations.py
@@ -1,5 +1,56 @@
+"""Game specific calculation helpers for Labyrinth of the Titans."""
+
 from src.executables.executables import Executables
+from src.calculations.cluster import Cluster
 
 
 class GameCalculations(Executables):
-    pass
+    """Collection of helper methods used by the game executables."""
+
+    # --- Cascade / win evaluation -------------------------------------------------
+    def evaluate_cascade(self) -> None:
+        """Evaluate current board, update wins and collect keys."""
+        clusters = Cluster.get_clusters(self.board, "wild")
+        return_data = {"totalWin": 0, "wins": []}
+        self.board, self.win_data, _ = Cluster.evaluate_clusters(
+            self.config,
+            self.board,
+            clusters,
+            global_multiplier=self.global_multiplier,
+            return_data=return_data,
+        )
+
+        Cluster.record_cluster_wins(self)
+        self.win_manager.update_spinwin(self.win_data["totalWin"])
+        self.win_manager.tumble_win = self.win_data["totalWin"]
+
+        # Collect any keys on the evaluated board for future wild spawns / boosts.
+        self.collect_keys()
+
+    # --- Multiplier ladder --------------------------------------------------------
+    def update_multiplier_ladder(self) -> None:
+        """Increase global multiplier based on collected keys."""
+        if not hasattr(self, "keys_collected"):
+            self.keys_collected = 0
+
+        # Define a simple ladder where every 3 keys grants +1 multiplier.
+        ladder_step = int(self.keys_collected / 3)
+        target_mult = 1 + ladder_step
+
+        while self.global_multiplier < target_mult:
+            self.update_global_mult()
+
+    # --- Key collection -----------------------------------------------------------
+    def collect_keys(self) -> None:
+        """Store positions of key symbols for later wild spawning."""
+        if not hasattr(self, "keys_collected"):
+            self.keys_collected = 0
+        if not hasattr(self, "pending_wilds"):
+            self.pending_wilds = []
+
+        for reel, _ in enumerate(self.board):
+            for row, symbol in enumerate(self.board[reel]):
+                if symbol.name == "K" or symbol.check_attribute("collector"):
+                    self.keys_collected += 1
+                    self.pending_wilds.append({"reel": reel, "row": row})
+

--- a/games/kyv_lab_titans/game_executables.py
+++ b/games/kyv_lab_titans/game_executables.py
@@ -1,6 +1,27 @@
+"""Executable helpers for Labyrinth of the Titans."""
+
 from game_calculations import GameCalculations
 
 
 class GameExecutables(GameCalculations):
+    """Grouped game actions triggered during play."""
 
-    pass
+    # --- Wild spawning ------------------------------------------------------------
+    def spawn_wilds(self) -> None:
+        """Replace collected key positions with wild symbols."""
+        if not hasattr(self, "pending_wilds"):
+            self.pending_wilds = []
+        for pos in self.pending_wilds:
+            self.board[pos["reel"]][pos["row"]] = self.create_symbol("W")
+        self.pending_wilds = []
+
+    # --- Key boosts ---------------------------------------------------------------
+    def handle_key_boosts(self) -> None:
+        """Apply multiplier ladder after key collection."""
+        self.update_multiplier_ladder()
+
+    # --- Free spin behaviour ------------------------------------------------------
+    def update_freespin(self) -> None:
+        """Persist multiplier while preparing new free spin."""
+        super().update_freespin()
+

--- a/games/kyv_lab_titans/gamestate.py
+++ b/games/kyv_lab_titans/gamestate.py
@@ -10,9 +10,32 @@ class GameState(GameStateOverride):
         self.reset_seed(sim)
         self.repeat = True
         while self.repeat:
+            # Reset simulation and key tracking for a new spin
             self.reset_book()
+            self.keys_collected = 0
+            self.pending_wilds = []
+
+            self.draw_board()
+            self.spawn_wilds()
+            self.evaluate_cascade()
+            self.emit_tumble_win_events()
+            self.handle_key_boosts()
+
+            while self.win_data["totalWin"] > 0 and not (self.wincap_triggered):
+                self.tumble_game_board()
+                self.spawn_wilds()
+                self.evaluate_cascade()
+                self.emit_tumble_win_events()
+                self.handle_key_boosts()
+
+            self.set_end_tumble_event()
+            self.win_manager.update_gametype_wins(self.gametype)
+
+            if self.check_fs_condition() and self.check_freespin_entry():
+                self.run_freespin_from_base()
 
             self.evaluate_finalwin()
+            self.check_repeat()
 
         self.imprint_wins()
 
@@ -20,6 +43,22 @@ class GameState(GameStateOverride):
         self.reset_fs_spin()
         while self.fs < self.tot_fs:
             self.update_freespin()
-            pass
+            self.spawn_wilds()
+            self.evaluate_cascade()
+            self.emit_tumble_win_events()
+            self.handle_key_boosts()
+
+            while self.win_data["totalWin"] > 0 and not (self.wincap_triggered):
+                self.tumble_game_board()
+                self.spawn_wilds()
+                self.evaluate_cascade()
+                self.emit_tumble_win_events()
+                self.handle_key_boosts()
+
+            self.set_end_tumble_event()
+            self.win_manager.update_gametype_wins(self.gametype)
+
+            if self.check_fs_condition():
+                self.update_fs_retrigger_amt()
 
         self.end_freespin()


### PR DESCRIPTION
## Summary
- add cascade evaluation with key collection and multiplier ladder
- spawn wilds from collected keys and persist multipliers during free spins
- integrate new mechanics into base game and free spin sequences

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a6bb5e86c8320b65c58b02b7e54ba